### PR TITLE
Polski OCR + trzy usterki, przez ktore PDF-y wychodzily jako smieci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,11 @@ docs/00-wejscie/
 eval/korpus-rzeczywisty/
 eval/sprawa-lacey/
 
-# Wagi modeli — duże i niezmienne; w repo tylko manifesty i sumy
+# Wagi modeli — duże i niezmienne; w repo tylko manifesty i sumy.
+# Dane językowe Tesseracta też są wagami (pol.traineddata to 11,4 MB),
+# więc idą tą samą drogą: plik poza repozytorium, suma kontrolna
+# w models/manifest.md.
+models/**/*.traineddata
 models/**/*.gguf
 models/**/*.safetensors
 models/**/*.bin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ as an incident rather than a bug.
 python -m pytest tests/ -q --dozwol-pominiecie
 ```
 
-Expected: `569 passed, 121 skipped, 1 warning`. The skips need Docker, the
+Expected: `577 passed, 123 skipped, 1 warning`. The skips need Docker, the
 OpenContracts fork or the measurement corpora; the warning is the deliberate
 J-3 gap. Anything failing is a genuine failure.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -295,14 +295,14 @@ python -m pytest tests/ -q --dozwol-pominiecie
 **You should see**, after about two minutes:
 
 ```
-569 passed, 121 skipped, 1 warning
+577 passed, 123 skipped, 1 warning
 ```
 
 **All three numbers are normal.** What they mean:
 
-- **569 passed** - if any fail, something is genuinely wrong; do not load real
+- **577 passed** - if any fail, something is genuinely wrong; do not load real
   case files until you know what.
-- **121 skipped** - tests needing Docker, the OpenContracts fork or the
+- **123 skipped** - tests needing Docker, the OpenContracts fork or the
   measurement corpora, none of which this guide installs. Skipped is the
   correct outcome here, not a failure.
 - **1 warning** - deliberate. It reads:

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Before anything else: please help an animal shelter in Wrocław 🐕
+# Before anything else: please help a dog shelter in Wrocław 🐕
 
-**This software is free. If it saves you time or money, please consider giving that value to animals in Polish shelter in Wrocław.**
+**This software is free. If it saves you time or money, please consider giving
+that value to animals who have nothing.**
 
 ### 👉 [ratujemyzwierzaki.pl/schroniskowroclaw](https://www.ratujemyzwierzaki.pl/schroniskowroclaw)
 
-**TOZ Schronisko dla Bezdomnych Zwierząt we Wrocławiu** - the *TOZ Shelter for
-Homeless Animals in Wrocław* - has been rescuing animals **since 1962**. Situated
+**TOZ Schronisko dla Bezdomnych Zwierząt we Wrocławiu** — the *TOZ Shelter for
+Homeless Animals in Wrocław* — has been rescuing animals **since 1962**. It is
 at 2 Ślazowa Street in Wrocław-Osobowice, run by **just over 30 employees**, some
 of whom are also inspectors for the Polish Society for the Prevention of Cruelty
-to Animals. They currently care for roughly **170 dogs and 140 cats**, plus
-rabbits, parrots, snakes and eleven Vietnamese pigs.
+to Animals. They currently care for roughly **170 dogs and 140 cats**.
 
-> *"Together with the Volunteers who support us, we strive for one thing - to
+> *"Together with the Volunteers who support us, we strive for one thing — to
 > help those who cannot ask for it themselves."*
 
-> **The donation page is in Polish only** - but it's possible to translate it using the internet browser. In Chrome,
+> **The donation page is in Polish only** — but it translates cleanly. In Chrome,
 > right-click anywhere on the page and choose **Translate to English** (Edge,
-> Firefox and Safari all have the same feature). The payment method works in the same way,
+> Firefox and Safari all have the same feature). Payment works the same
 > regardless of language.
 
 > ### ⚠️ This is not our fundraiser.
@@ -27,27 +27,41 @@ rabbits, parrots, snakes and eleven Vietnamese pigs.
 > attention more than we deserve your payment.
 >
 > Every złoty goes directly to the shelter through **ratujemyzwierzaki.pl**,
-> a Polish donation platform. Verify it yourself before donating.
+> a Polish donation platform. Verify it yourself before giving — we would rather
+> you check than trust us.
 
 ### Why we are asking now
 
-**Winter is coming, and it's the hardest season that the shelter faces.** Cold weather
-drives up every cost at once: heating itself can run into thousands of złoty per
-month, animals need higher-calorie food just to keep their body temperature up,
-and vets see a spike in frostbite and respiratory infections among the older
-and sicker animals - the ones nobody adopts first. Winter is also a time when
-shelters see an influx of animals given up as unwanted Christmas gifts.
+**Winter is the hard season for every shelter.** Heating costs rise exactly when
+donations fall. Food stocks run down. Medicine for older and sick animals — the
+ones nobody adopts — becomes the first thing a stretched budget cannot cover.
 
-These aren't abstract problems - they're real bills for heating, food, and vet care. 
-That's what your donation goes toward.
+Their three open fundraisers, **as checked on 17 August 2026**:
+
+| Fundraiser | Raised | Still needed |
+|---|---:|---:|
+| *Dla nich najważniejsza meta to własny dom!* | 2 696,37 zł | 27 303,63 zł |
+| *Koci sezon trwa!* (~300 cats in care) | 4 128 zł | 5 872 zł |
+| *Leczymy bezdomniaki* (veterinary care) | 3 757 zł | 46 243 zł |
+
+> **These numbers are a snapshot, not a live figure.** They change every day.
+> Open the link above for the real state — never rely on a table in a README.
 
 You can give **10, 20, 50 or 100 zł once**, or **20–50 zł monthly**. You can also
-"virtually adopt" a specific animal.
+"virtually adopt" a specific animal. Small and regular beats large and never.
 
+### Why we are giving this away
 
-If you are a law firm and this replaces a paid tool, please donate. If you are a student, a solo practitioner, or just curious -
-use it and enjoy it. **No one is checking. There is no licence
-key.** The request above is a request, never a condition.
+This system took real work: measured, tested, documented. It could have been sold
+to law firms — that market pays well, and there is no good local-only competitor
+in Polish.
+
+We would rather it be free and have the shelter get the money instead.
+
+If you are a law firm and this replaces a paid tool, please donate roughly what
+you would have paid. If you are a student, a solo practitioner, or just curious —
+use it, donate nothing, and enjoy it. **No one is checking. There is no licence
+key. Nothing phones home.** The request above is a request, never a condition.
 
 ---
 ---
@@ -59,13 +73,13 @@ key.** The request above is a request, never a condition.
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg)](pyproject.toml)
 [![bez zależności](https://img.shields.io/badge/runtime%20dependencies-none-brightgreen.svg)](pyproject.toml)
 
-**A fully local AI system for analysing legal case files - built for Polish
+**A fully local AI system for analysing legal case files — built for Polish
 lawyers, in Polish, for Polish legal reality.**
 
 > **Language note.** This README and the setup guide are in English so anyone can
 > evaluate the project. **Everything else is deliberately Polish**: the interface,
 > the documentation in `docs/`, the code comments, and the legal logic. This is
-> not an oversight - it is a product for Polish advocates and legal counsel,
+> not an oversight — it is a product for Polish advocates and legal counsel,
 > handling Polish case files under Polish procedure (k.p.k., k.p.c., procedural
 > deadlines, court reference numbers, professional secrecy). Translating it would
 > make it worse, not more useful.
@@ -74,40 +88,67 @@ lawyers, in Polish, for Polish legal reality.**
 
 You load the case file. You ask a question in plain Polish. You get an answer
 where **every single sentence points to the exact place in the document it came
-from - down to the character.**
+from — down to the character.**
 
 Click a citation and the source opens with that passage highlighted. Not a page
 number. Not a paraphrase. The actual sentence.
+
+### Loading files, and being honest about scans
+
+PDF, DOCX, TXT and RTF, dragged in or picked, many at once — no Python
+dependencies added for any of it. Measured on **173 real-world PDFs**
+(contracts, invoices, offers, technical documentation, signed letters):
+**87 read from the text layer, 16 through OCR, 70 refused with an explanation.**
+
+Refusal is a correct outcome here. Extracted text becomes the **source of
+citations**, and the verifier compares citations against it character by
+character — so a bad extraction would break the whole guarantee silently:
+the citation would verify against corrupted text.
+
+**OCR is available, local, and never silent about itself.** Tesseract with the
+Polish language pack, run as a separate process. It is switched on by a click,
+never automatically, because it changes what the core promise means:
+
+> *a citation points to an exact character in the case file* becomes
+> *a citation points to an exact character **in the reading of a scan***
+
+That reading is wrong most often in signatures, amounts and dates — in our
+measurement a handwritten date came out as `4 9.03.2026`. So a document read
+this way carries a **permanent marker**, every citation from it shows `z OCR`
+and a *check against the original* warning, and text provenance is tracked for
+every route in: pasted · file · OCR.
+
+Full numbers and limits: [`docs/23-wczytywanie-i-ocr.md`](docs/23-wczytywanie-i-ocr.md)
 
 ## What makes it different
 
 **The model never writes a quotation.** It selects a *sentence number*, and the
 code reconstructs the text from the source document. A fabricated citation is not
-"detected and rejected" - it is **impossible to express**.
+"detected and rejected" — it is **impossible to express**.
 
 Measured on real-scale case files (722 documents, one Polish and one English
 case, 100 matched questions):
 
 | | |
 |---|---|
-| Citations inconsistent with the source | **0** - in every measurement run, without exception |
+| Citations inconsistent with the source | **0** — in every measurement run, without exception |
 | For comparison: leading commercial legal AI tools (Stanford study) | **17–34% fabricated citations** |
 | Citation accuracy | **above 80%** |
 | Correctly refusing when the files give no answer | **above 80%** |
 | Data sent anywhere | **0 bytes** |
 
 Every answerable question has an identically-worded twin that the files
-**cannot** answer - so "always answer" and "always refuse" both score zero.
+**cannot** answer — so "always answer" and "always refuse" both score zero.
 
 **We also publish the numbers that look bad.** See
-[`docs/22-wyniki-docelowe.md`](docs/22-wyniki-docelowe.md) - including where the
+[`docs/22-wyniki-docelowe.md`](docs/22-wyniki-docelowe.md) — including where the
 system still falls short of its own targets, and four hypotheses we tested and
 had to throw away.
 
 > ### Which profile these numbers belong to
 >
-> They were measured on the **development profile** - Q4_K_M quantisation, 8 GB
-> of VRAM - which is what [QUICKSTART](QUICKSTART.md) installs and what most
+> They were measured on the **development profile** — Q4_K_M quantisation, 8 GB
+> of VRAM — which is what [QUICKSTART](QUICKSTART.md) installs and what most
 > people will run. **This project's own compliance documents do not approve that
 > profile for real case files**; they require Q8_0 or higher, which needs 24 GB.
 >
@@ -116,7 +157,7 @@ had to throw away.
 > whole project exists to avoid. Details:
 > [before you load real case files](QUICKSTART.md#before-you-load-real-case-files).
 
-## Fully local - enforced, not promised
+## Fully local — enforced, not promised
 
 Nothing leaves the machine. Not case text, not fragments, not queries, not
 metadata, not usage statistics.
@@ -125,8 +166,8 @@ Three independent layers enforce this:
 
 | Layer | Mechanism |
 |---|---|
-| **Code** | No cloud SDKs. The model address is validated at import - **a non-loopback address stops the process from starting.** A test scans the codebase so nobody can quietly add a second network call. |
-| **Network** | Four Docker segments, three with `internal: true` - no route to the gateway. |
+| **Code** | No cloud SDKs. The model address is validated at import — **a non-loopback address stops the process from starting.** A test scans the codebase so nobody can quietly add a second network call. |
+| **Network** | Four Docker segments, three with `internal: true` — no route to the gateway. |
 | **Proof** | Traffic captured at packet level while a container inside each segment actively tried to reach the internet: **zero packets left.** |
 
 It runs with the network cable unplugged. That is the simplest demonstration you
@@ -152,7 +193,7 @@ chain**, and a quality journal that never stores case content.
 
 ## Getting started
 
-**→ [QUICKSTART.md](QUICKSTART.md)** - written for someone who has never used a
+**→ [QUICKSTART.md](QUICKSTART.md)** — written for someone who has never used a
 command line. About 30 minutes, most of it waiting for model downloads.
 
 **Check the hardware first.** [Step 0](QUICKSTART.md#step-0--will-it-run-on-your-computer)
@@ -164,13 +205,13 @@ tells you whether this machine can run it *before* you download 9 GB:
 | RAM | 16 GB | 32 GB |
 | Free disk | 15 GB | 25 GB |
 
-It runs without a graphics card, but we measured it at **13× slower** - usable
+It runs without a graphics card, but we measured it at **13× slower** — usable
 for trying it out, painful for daily work. Apple Silicon shares memory, so a
 16 GB Mac takes the fast path.
 
 The setup guide **pins the exact model versions by digest**. Two models with the
 same name are not the same model, and the accuracy figures below belong to
-specific weights - [Step 3](QUICKSTART.md#step-3--download-the-two-language-models)
+specific weights — [Step 3](QUICKSTART.md#step-3--download-the-two-language-models)
 tells you how to confirm you have them.
 
 Windows, macOS or Linux. No internet connection needed after setup.
@@ -187,7 +228,7 @@ All in `docs/`, in Polish:
 | [`22-wyniki-docelowe.md`](docs/22-wyniki-docelowe.md) | Measurements, including the unflattering ones |
 | [`15-rejestr-ryzyk.md`](docs/15-rejestr-ryzyk.md) | Open risks, honestly listed |
 
-Benchmark corpora are **not** in this repository - see
+Benchmark corpora are **not** in this repository — see
 [`eval/README.md`](eval/README.md) for how to obtain them. They are public
 sources; they are simply large, and this project's first rule is that real case
 files never enter a repository.
@@ -197,20 +238,20 @@ files never enter a repository.
 The only current version lives at
 **[github.com/AI4CharityPL/kancelaria-lex](https://github.com/AI4CharityPL/kancelaria-lex)**.
 
-A copy received any other way - by email, on a drive, from an intermediary - is
+A copy received any other way — by email, on a drive, from an intermediary — is
 not official, and you cannot know what was changed in it.
 
 ## Licence and liability
 
-MIT - see [LICENSE](LICENSE). Use it, sell services around it, fork it.
+MIT — see [LICENSE](LICENSE). Use it, sell services around it, fork it.
 
 Provided **as is**, without warranty. The authors are not liable for:
 
-- **misuse** - in particular relying on an answer without opening the citation;
+- **misuse** — in particular relying on an answer without opening the citation;
 - **modified versions** or copies from outside the official source. Changing the
   code can remove exactly the safeguards this whole argument rests on: network
   isolation and citation verification;
-- **the firm's own legal obligations** - KSC assessment and registration, DPIA
+- **the firm's own legal obligations** — KSC assessment and registration, DPIA
   approval, disk encryption, staff training.
 
 **Professional responsibility for any document you sign remains entirely yours.**

--- a/docs/23-wczytywanie-i-ocr.md
+++ b/docs/23-wczytywanie-i-ocr.md
@@ -1,0 +1,185 @@
+# 23 — Wczytywanie akt i OCR: co zmierzono i na czym
+
+Dokument opisuje, **na jakich danych** i **w jakiej ilości** sprawdzono
+ścieżkę wczytywania dokumentów, oraz gdzie leżą jej granice. Powstał
+19.08.2026, przed publikacją repozytorium.
+
+> **Zasada nadrzędna tej ścieżki.** Tekst wydobyty z pliku staje się
+> **źródłem cytatów**: weryfikator porównuje z nim cytat znak w znak.
+> Błędna ekstrakcja rozsypuje więc cały łańcuch gwarancji po cichu —
+> cytat przechodzi weryfikację wobec zepsutego źródła. Dlatego każda
+> ścieżka kończy się bramką jakości, a **odmowa jest wynikiem poprawnym**.
+
+---
+
+## 1. Korpus pomiarowy
+
+| Cecha | Wartość |
+|---|---|
+| Liczba plików | **173 PDF-y** |
+| Pochodzenie | katalog `Pobrane` maszyny deweloperskiej — dokumenty rzeczywiste, nie syntetyczne |
+| Rodzaje | umowy i NDA, listy intencyjne, oferty handlowe, faktury i wydruki księgowe, dokumentacja techniczna, życiorysy, pisma z podpisem odręcznym |
+| Języki | polski i angielski, część dokumentów mieszana |
+| Zakres wielkości | 35 kB – 9,1 MB |
+
+⚠️ **Te pliki nie znajdują się w repozytorium i nigdy się w nim nie
+znajdą.** To dokumenty prywatne i firmowe osoby prowadzącej projekt;
+posłużyły wyłącznie jako materiał pomiarowy na maszynie lokalnej.
+W repozytorium zostają **same liczby**, zgodnie z wymaganiem T-6.
+
+Korpus jest przypadkowy i to jest jego zaletą: nie został dobrany pod
+możliwości parsera. Zawiera dokładnie to, co trafia do kancelarii —
+pisma z pieczątką, skany podpisanych umów i wydruki z systemów
+księgowych.
+
+---
+
+## 2. Wynik końcowy
+
+| Kategoria | Plików | Udział |
+|---|---:|---:|
+| **Odczytane z warstwy tekstowej** | **87** | 50,3% |
+| **Odczytane przez OCR** | **16** | 9,2% |
+| Odrzucone z wyjaśnieniem | 70 | 40,5% |
+| **Razem użytecznych** | **103** | **59,5%** |
+
+OCR: **147 stron**, 39 175 znaków, z czego 1 127 to znaki diakrytyczne
+(2,9%), czas łączny **2,9 minuty** — około 1,2 s na stronę.
+
+---
+
+## 3. Droga do tego wyniku — trzy usterki, każda zmierzona
+
+Na starcie pomiaru odczytywało się **75 plików ze 173**. Trzy poprawki
+podniosły to do 87 na samej warstwie tekstowej.
+
+### 3.1. Filtr obrazów odrzucał tekst całych stron
+
+Warunek `b"/Image" in cialo` szukał ciągu w **całym obiekcie razem ze
+skompresowanym strumieniem**. Zamiarem było pominięcie obrazów; skutkiem
+— odrzucenie **całego strumienia treści strony**, gdy tylko gdziekolwiek
+trafił się ciąg `/Image`. A trafia się zawsze, gdy strona ma logo,
+pieczątkę, podpis albo tło.
+
+Pisma procesowe mają nagłówek kancelarii i pieczęć niemal zawsze, więc
+usterka trafiała w przypadek **typowy, nie brzegowy**.
+
+Pierwsza poprawka nie zmieniła nic, bo szukała pary `/Subtype` + `/Image`
+w słowniku, a ten niesie `/ProcSet [/PDF /Text /ImageB /ImageC]` — czyli
+`/Image` jako przedrostek `/ImageB`. Dopiero dopasowanie **pary
+`/Subtype /Image`** zadziałało.
+
+### 3.2. Mapy `/ToUnicode` budowane i nieużywane
+
+PDF nie przechowuje tekstu, tylko numery glifów. Dopiero mapa
+`/ToUnicode` mówi, co dany glif znaczy. Wiązanie nazwy zasobu (`/F4`)
+z mapą szło przez `re.search(rb"/Font\s*<<(.*?)>>")` — a słownik zasobów
+jest **zagnieżdżony**, więc `(.*?)>>` zatrzymywał się na pierwszym `>>`,
+zwykle nie na właściwym.
+
+Zmierzone na pliku testowym: **10 map zbudowanych, 10 fontów użytych,
+zero powiązań**. Każdy znak szedł ścieżką zapasową cp1252 i wychodził
+jako przypadkowy bajt. Wiązanie idzie teraz po całym dokumencie.
+
+### 3.3. Każdy operator pozycjonowania łamał wiersz
+
+`Td` traktowany bezwarunkowo jako nowy wiersz dawał tekst rozsypany na
+litery — generatory PDF ustawiają pozycję **osobno dla każdego znaku**.
+Nowy wiersz jest wtedy i tylko wtedy, gdy zmienia się współrzędna
+pionowa.
+
+Przy okazji zmierzono rozkład przesunięć poziomych (3294 próbki, stopień
+pisma 12–13):
+
+| kwantyl | 0,10 | 0,50 | 0,75 | 0,97 |
+|---|---:|---:|---:|---:|
+| przesunięcie | 3,15 | 6,41 | 7,14 | 10,38 |
+
+Odstępy międzyliterowe i międzywyrazowe **nie rozdzielają się progiem** —
+rozkład jest jednomodalny, bo ten generator wstawia spacje jako osobne
+glify. Dokładanie spacji progiem 1,2 psuło 6053 znaki na 3524 poprawne
+(`C o n t a c t` zamiast `Contact`). Próg jest teraz ułamkiem stopnia
+pisma i dokłada spację wyłącznie przy skoku wyraźnie większym niż
+szerokość znaku.
+
+---
+
+## 4. OCR — konfiguracja i granice
+
+| Element | Stan |
+|---|---|
+| Silnik | Tesseract 5.4.0, wywoływany jako **osobny proces** |
+| Dane językowe | `models/tessdata/` — `pol`, `eng`, `osd`, przypięte sumą `sha256` w [`models/manifest.md`](../models/manifest.md) |
+| Zależności Pythona | **zero** — obrazy wydobywane `zlib` i `struct` z biblioteki standardowej |
+| Uprawnienia | nie wymaga administratora: `TESSDATA_PREFIX` wskazuje katalog projektu |
+
+### Polski jest wymagany, angielski nie wystarcza
+
+Zmierzone na zdaniu z polskiego postanowienia:
+
+```
+pol:  Sąd Okręgowy … oddalił wniosek obrońcy o dopuszczenie
+eng:  Sad Okregowy … oddalit wniosek obroncy 0 dopuszezenie
+```
+
+Angielski **„działa"** i zwraca tekst wyglądający poprawnie — bez ani
+jednego znaku diakrytycznego, z zerem zamiast litery `o` i przekręconym
+`dopuszezenie`. Brak polskiego pakietu jest więc **odmową**, nie
+zejściem na angielski.
+
+### Czego OCR tutaj nie zrobi
+
+Obrazy są **wydobywane z PDF-a**, nie renderowane. Skan zapisany jako
+PDF ma stronę będącą obrazem, więc wystarczy ten obraz wyjąć
+(`/DCTDecode` to gotowy JPEG, `/FlateDecode` składamy w PNG). Renderowanie
+wymagałoby silnika (poppler, Ghostscript) — kolejnego programu do
+przypięcia i pilnowania.
+
+Skutek: **70 plików pozostaje nieodczytanych.** To PDF-y wektorowe
+z warstwą tekstową, której nie da się rozszyfrować bez pełnego rozbioru
+kodowań PDF-a — nie ma w nich obrazu do rozpoznania. Panel mówi to
+wprost zamiast zwracać pusty dokument.
+
+---
+
+## 5. ⚠️ OCR zmienia charakter głównej gwarancji
+
+Obietnica systemu brzmi: *cytat prowadzi do konkretnego znaku w aktach*.
+Przy dokumencie z OCR-u prawdziwe zdanie brzmi inaczej:
+
+> cytat prowadzi do konkretnego znaku **w odczycie skanu**
+
+Przykład z pomiaru — nagłówek listu intencyjnego rozpoznany poprawnie
+(`dotyczący utworzenia spółki kapitałowej`), ale data z odręcznego
+wypełnienia wyszła jako **`4 9.03.2026`**. W kontekście terminu
+procesowego to jest różnica między dochowaniem terminu a jego utratą.
+
+Dlatego:
+
+- dokument wczytany przez OCR dostaje **trwały znacznik** `zrodlo_tekstu = "ocr"`
+  w bazie, widoczny na liście dokumentów;
+- **każdy cytat** z takiego dokumentu niesie znacznik `z OCR` i ostrzeżenie
+  „sprawdź przy oryginale, zwłaszcza sygnatury, kwoty i daty";
+- znacznik jest wystawiany **bezwarunkowo**, poza przełącznikami kontroli
+  wsparcia — ostrzeżenie gasnące przy zmianie niezwiązanego przełącznika
+  byłoby gorsze od jego braku;
+- OCR **nie włącza się sam**. Jest ostatnią deską po odrzuceniu przez
+  bramkę jakości i wymaga kliknięcia „Rozpoznaj pismo".
+
+Pochodzenie tekstu jest śledzone dla **wszystkich** dróg wejścia:
+`wklejony` (wprost do panelu), `plik` (TXT, MD, DOCX, RTF, PDF z warstwą
+tekstową) oraz `ocr`.
+
+---
+
+## 6. Powtórzenie pomiaru
+
+Pomiar nie jest częścią przebiegu testów — wymaga katalogu z prawdziwymi
+PDF-ami, których w repozytorium nie ma i nie będzie. Testy jednostkowe
+(`tests/test_ocr.py`, `tests/test_wczytywanie.py`) sprawdzają natomiast
+zachowanie na plikach budowanych w kodzie, w tym **odmowę przy braku
+polskiego pakietu** i **oznaczanie pochodzenia**.
+
+Żeby powtórzyć pomiar na własnym zbiorze, wskaż katalog i policz
+`wczytaj(nazwa, dane)` oraz `wczytaj(nazwa, dane, ocr_dozwolony=True)`
+dla każdego pliku — patrz `panel/wczytywanie.py`.

--- a/models/manifest.md
+++ b/models/manifest.md
@@ -129,3 +129,20 @@ a18a44fad1d0b46ded15928144138cff1135d5cc8233bdd90be5f18822de09a7  model.safetens
 udostępnia intfloat na licencji MIT — do potwierdzenia przy każdej
 aktualizacji, tak samo jak przy Bieliku. Same pliki wag są wyłączone
 z repozytorium (`.gitignore`), bo ważą 1,1 GB.
+
+
+## Dane językowe OCR (Tesseract)
+
+Katalog `models/tessdata/`. Pliki **nie są wersjonowane** — pobiera się
+je raz i sprawdza sumą. `TESSDATA_PREFIX` wskazuje ten katalog, więc
+instalacja nie wymaga uprawnień administratora.
+
+| Plik | Rozmiar | sha256 | Źródło |
+|---|---:|---|---|
+| `pol.traineddata` | 11,4 MB | `e80cc4cefbdface06e9223f43f089556b9dcf104020fbc0a200f6863c57d4405` | `tesseract-ocr/tessdata_best` |
+| `eng.traineddata` | 3,9 MB | `7d4322bd2a7749724879683fc3912cb542f19906c83bcc1a52132556427170b2` | instalacja Tesseract 5.4.0 |
+| `osd.traineddata` | 10,1 MB | `9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff` | instalacja Tesseract 5.4.0 |
+
+⚠️ **Polski jest wymagany, angielski nie jest zamiennikiem.** Rozpoznanie
+polskiego pisma silnikiem angielskim zwraca tekst bez znaków
+diakrytycznych — patrz [`docs/23-wczytywanie-i-ocr.md`](../docs/23-wczytywanie-i-ocr.md).

--- a/panel/analiza.py
+++ b/panel/analiza.py
@@ -615,7 +615,8 @@ def analizuj(pytanie: str,
              nazwy_przepisow: dict[str, str] | None = None,
              postep: Callable[[str, int, int], None] | None = None,
              maks_dokumentow: int = MAKS_DOKUMENTOW_DO_ANALIZY,
-             jezyki: dict[str, str] | None = None) -> WynikAnalizy:
+             jezyki: dict[str, str] | None = None,
+             zrodla: dict[str, str] | None = None) -> WynikAnalizy:
     """Pełna analiza. `dokumenty` pochodzą WYŁĄCZNIE z jednej sprawy.
 
     `postep(etap, zrobione, wszystkie)` pozwala pokazać, co się dzieje —
@@ -716,6 +717,31 @@ def analizuj(pytanie: str,
         melduj("Sprawdzam wsparcie ustaleń", 0, len(potwierdzone))
         potwierdzone = _sprawdz_wsparcie_ustalen(
             potwierdzone, wynik, pytanie, melduj)
+
+        # ── POCHODZENIE TEKSTU NA KAŻDYM CYTACIE ────────────────────
+        #
+        # ⚠️ BEZWARUNKOWO, POZA PRZEŁĄCZNIKAMI KONTROLI.
+        #
+        # Cytat z pliku cyfrowego i cytat z OCR-u wyglądają identycznie,
+        # a znaczą co innego: pierwszy jest treścią pisma, drugi jego
+        # ODCZYTEM — i myli się najczęściej w sygnaturach, kwotach
+        # i datach, czyli tam, gdzie stoją wyróżniki i terminy.
+        #
+        # Gdyby to oznaczenie siedziało w `_sprawdz_wsparcie_ustalen`,
+        # znikałoby razem z wyłączoną kontrolą. Ostrzeżenie, które
+        # gaśnie przy zmianie niezwiązanego przełącznika, jest gorsze
+        # od jego braku, bo raz się pojawia, a raz nie.
+        if zrodla:
+            for u in potwierdzone:
+                for c in u.cytaty:
+                    pochodzenie = zrodla.get(str(c.get("dokument_id")), "")
+                    if not pochodzenie:
+                        continue
+                    c["zrodlo_tekstu"] = pochodzenie
+                    if pochodzenie == "ocr":
+                        c["ostrzezenie_zrodla"] = (
+                            "Tekst z rozpoznania obrazu (OCR) — sprawdź przy "
+                            "oryginale, zwłaszcza sygnatury, kwoty i daty.")
 
         wynik.ustalenia = potwierdzone
 

--- a/panel/baza.py
+++ b/panel/baza.py
@@ -281,8 +281,19 @@ def _domiguj(db) -> None:
     rozpoznawania języka wywracałaby zapytania na nieznanej kolumnie.
     """
     istniejace = {w["name"] for w in db.execute("PRAGMA table_info(dokumenty)")}
+    # ⚠️ `zrodlo_tekstu` — SKĄD WZIĄŁ SIĘ TEKST DOKUMENTU.
+    #
+    # „wklejony" (wprost do panelu), „plik" (TXT, MD, DOCX, RTF, PDF
+    # z warstwą tekstową) albo „ocr" (odczyt obrazu). Rozróżnienie jest
+    # potrzebne przy KAŻDYM cytacie: tekst z pliku jest treścią pisma,
+    # tekst z OCR-u jest jego odczytem i bywa różny — najczęściej
+    # w sygnaturach, kwotach i datach.
+    #
+    # Domyślna wartość dla dokumentów sprzed tej kolumny to „wklejony",
+    # bo panel nie miał wtedy innej drogi wejścia.
     for kolumna, definicja in (("jezyk", "TEXT DEFAULT ''"),
-                               ("jezyk_pewnosc", "REAL DEFAULT 0.0")):
+                               ("jezyk_pewnosc", "REAL DEFAULT 0.0"),
+                               ("zrodlo_tekstu", "TEXT DEFAULT 'wklejony'")):
         if kolumna not in istniejace:
             db.execute(f"ALTER TABLE dokumenty ADD COLUMN {kolumna} {definicja}")
     # Dopiero teraz — kolumna na pewno istnieje.
@@ -442,7 +453,8 @@ def pobierz_sprawe(db, sprawa_id: int) -> dict | None:
 # ── dokumenty — zawsze w obrębie sprawy ─────────────────────────────
 
 def dodaj_dokument(db, sprawa_id: int, nazwa: str, tresc: str,
-                   rodzaj: str = "pismo") -> int:
+                   rodzaj: str = "pismo",
+                   zrodlo_tekstu: str = "wklejony") -> int:
     """Dodaje dokument DO WSKAZANEJ SPRAWY.
 
     Nie istnieje wariant bez `sprawa_id` — dokument nie może zawisnąć
@@ -471,9 +483,10 @@ def dodaj_dokument(db, sprawa_id: int, nazwa: str, tresc: str,
 
     kursor = db.execute(
         "INSERT INTO dokumenty (sprawa_id, nazwa, rodzaj, tresc, jezyk, "
-        "jezyk_pewnosc, dodano) VALUES (?,?,?,?,?,?,?)",
+        "jezyk_pewnosc, dodano, zrodlo_tekstu) VALUES (?,?,?,?,?,?,?,?)",
         (sprawa_id, nazwa.strip(), rodzaj, tresc,
-         rozpoznanie.jezyk, round(rozpoznanie.pewnosc, 3), _teraz()),
+         rozpoznanie.jezyk, round(rozpoznanie.pewnosc, 3), _teraz(),
+         zrodlo_tekstu),
     )
     db.commit()
     zapisz_audyt(db, "dodanie_dokumentu", sprawa_id,
@@ -485,11 +498,25 @@ def lista_dokumentow(db, sprawa_id: int) -> list[dict]:
     """Metadane dokumentów JEDNEJ sprawy (bez treści)."""
     wiersze = db.execute(
         "SELECT id, sprawa_id, nazwa, rodzaj, LENGTH(tresc) AS dlugosc, "
-        "jezyk, jezyk_pewnosc, dodano "
+        "jezyk, jezyk_pewnosc, dodano, zrodlo_tekstu "
         "FROM dokumenty WHERE sprawa_id = ? ORDER BY id",
         (sprawa_id,),
     ).fetchall()
     return [dict(w) for w in wiersze]
+
+
+def zrodla_dokumentow(db, sprawa_id: int) -> dict[str, str]:
+    """Mapa {id_dokumentu: pochodzenie tekstu}.
+
+    ⚠️ Potrzebna przy KAŻDYM cytacie, nie tylko na liście dokumentów.
+    Cytat z pliku cyfrowego i cytat z OCR-u wyglądają identycznie,
+    a znaczą co innego: pierwszy jest treścią pisma, drugi jego
+    odczytem. Bez tej mapy panel nie ma z czego zbudować ostrzeżenia.
+    """
+    return {str(w["id"]): (w["zrodlo_tekstu"] or "wklejony")
+            for w in db.execute(
+                "SELECT id, zrodlo_tekstu FROM dokumenty WHERE sprawa_id = ?",
+                (sprawa_id,))}
 
 
 def jezyki_dokumentow(db, sprawa_id: int) -> dict[str, str]:

--- a/panel/ocr.py
+++ b/panel/ocr.py
@@ -1,0 +1,296 @@
+"""Rozpoznawanie pisma ze skanów (OCR) — Tesseract, lokalnie.
+
+════════════════════════════════════════════════════════════════════════
+ PO CO
+════════════════════════════════════════════════════════════════════════
+
+Na 173 rzeczywistych PDF-ach zmierzonych 19.08.2026 czternaście nie ma
+warstwy tekstowej w ogóle, a dalsze kilkadziesiąt ma fonty, których nie
+da się wiarygodnie odczytać bez pełnego rozbioru kodowań PDF-a. Dla obu
+grup OCR jest właściwą odpowiedzią — a `wczytywanie.py` i tak je już
+rozpoznaje i odrzuca.
+
+════════════════════════════════════════════════════════════════════════
+ ⚠️ OCR ZMIENIA CHARAKTER GŁÓWNEJ GWARANCJI SYSTEMU
+════════════════════════════════════════════════════════════════════════
+
+Obietnica brzmi: „cytat prowadzi do konkretnego znaku w aktach". Przy
+dokumencie z OCR-u prawdziwe zdanie brzmi inaczej:
+
+    cytat prowadzi do konkretnego znaku W ODCZYCIE SKANU
+
+a odczyt bywa różny od pisma. Nawet dobry OCR myli 1 z l, 0 z O i gubi
+znaki w pieczątkach — czyli akurat w sygnaturach, kwotach i datach,
+na których stoją wyróżniki i terminy procesowe.
+
+Dlatego dokument wczytany tą drogą dostaje TRWAŁY ZNACZNIK pochodzenia,
+a każdy cytat z niego — ostrzeżenie „sprawdź przy oryginale". Bez tego
+system obiecywałby dokładność, której przy skanie nie ma.
+
+════════════════════════════════════════════════════════════════════════
+ DLACZEGO TESSERACT JAKO PROGRAM, A NIE BIBLIOTEKA
+════════════════════════════════════════════════════════════════════════
+
+Panel korzysta wyłącznie z biblioteki standardowej (art. 21 ust. 2
+lit. d ustawy o KSC). `pytesseract` czy `pdf2image` byłyby nowymi
+zależnościami Pythona; Tesseract wywoływany jako osobny proces nie jest
+— tak samo jak Ollama, od której panel zależy od początku.
+
+⚠️ POLSKI JEST WYMAGANY, ANGIELSKI NIE WYSTARCZY.
+   Zmierzone 19.08.2026 na zdaniu z polskiego postanowienia:
+
+       pol:  Sąd Okręgowy … oddalił wniosek obrońcy o dopuszczenie
+       eng:  Sad Okregowy … oddalit wniosek obroncy 0 dopuszezenie
+
+   Angielski „działa" i zwraca tekst wyglądający poprawnie — bez ani
+   jednego znaku diakrytycznego, z zerem zamiast litery o i przekręconym
+   „dopuszezenie". To jest dokładnie ten rodzaj cichego zepsucia,
+   przed którym broni bramka jakości. Brak polskiego pakietu to więc
+   ODMOWA, nie zejście na angielski.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import struct
+import subprocess
+import tempfile
+import zlib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+KORZEN = Path(__file__).resolve().parents[1]
+
+# Dane językowe trzymamy przy projekcie, nie w Program Files: instalacja
+# nie wymaga wtedy uprawnień administratora, a wersja jest przypięta sumą
+# kontrolną w `models/manifest.md`.
+TESSDATA = KORZEN / "models" / "tessdata"
+
+# Kolejność szukania: PATH, potem typowe miejsca instalacji na Windows.
+KANDYDACI = (
+    "tesseract",
+    r"C:\Program Files\Tesseract-OCR\tesseract.exe",
+    r"C:\Program Files (x86)\Tesseract-OCR\tesseract.exe",
+)
+
+JEZYKI = {"pl": "pol", "en": "eng"}
+
+# Skan strony A4 przy 300 dpi to kilkanaście sekund pracy procesora.
+TIMEOUT_S = 300
+
+
+class BladOCR(RuntimeError):
+    """OCR nie mógł się wykonać — do pokazania użytkownikowi wprost."""
+
+
+@dataclass
+class WynikOCR:
+    tekst: str
+    stron: int = 0
+    jezyk: str = "pol"
+    ostrzezenia: list[str] = field(default_factory=list)
+
+
+# ── dostępność ───────────────────────────────────────────────────────
+
+def sciezka_programu() -> str | None:
+    for kandydat in KANDYDACI:
+        if os.sep in kandydat:
+            if Path(kandydat).exists():
+                return kandydat
+            continue
+        znaleziony = shutil.which(kandydat)
+        if znaleziony:
+            return znaleziony
+    return None
+
+
+def _srodowisko() -> dict:
+    srodowisko = dict(os.environ)
+    if TESSDATA.exists():
+        srodowisko["TESSDATA_PREFIX"] = str(TESSDATA)
+    return srodowisko
+
+
+def jezyki_dostepne() -> set[str]:
+    program = sciezka_programu()
+    if not program:
+        return set()
+    try:
+        wynik = subprocess.run([program, "--list-langs"], capture_output=True,
+                               text=True, env=_srodowisko(), timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {w.strip() for w in (wynik.stdout or "").splitlines()
+            if w.strip() and " " not in w.strip()}
+
+
+def stan() -> dict:
+    """Stan OCR do pokazania w panelu — bez zgadywania."""
+    program = sciezka_programu()
+    jezyki = jezyki_dostepne() if program else set()
+    return {
+        "dostepny": bool(program) and "pol" in jezyki,
+        "program": program or "",
+        "jezyki": sorted(jezyki),
+        "polski": "pol" in jezyki,
+        "tessdata": str(TESSDATA) if TESSDATA.exists() else "",
+    }
+
+
+# ── obrazy osadzone w PDF ────────────────────────────────────────────
+#
+# ⚠️ WYDOBYWAMY OBRAZY ZAMIAST RENDEROWAĆ STRONĘ.
+#
+# Renderowanie PDF-a wymaga silnika (poppler, Ghostscript) — kolejnego
+# programu do przypięcia i pilnowania. Skan zapisany jako PDF ma jednak
+# stronę BĘDĄCĄ obrazem, więc wystarczy ten obraz wyjąć:
+#
+#     /DCTDecode   — strumień JEST plikiem JPEG, zapisujemy go wprost
+#     /FlateDecode — mapa bitowa; składamy z niej PNG, bo PNG to nagłówek
+#                    plus te same dane spakowane zlibem
+#
+# Czego to NIE obsłuży: stron wektorowych, czyli PDF-ów z warstwą
+# tekstową, której nie umiemy odczytać. Tam potrzebny byłby renderer
+# i jest to zapisane wprost w ograniczeniach.
+
+_OBIEKT = re.compile(rb"(\d+)\s+(\d+)\s+obj(.*?)endobj", re.DOTALL)
+_STRUMIEN = re.compile(rb"stream\r?\n(.*?)\r?\nendstream", re.DOTALL)
+
+
+def _liczba(slownik: bytes, klucz: bytes) -> int | None:
+    m = re.search(klucz + rb"\s+(\d+)", slownik)
+    return int(m.group(1)) if m else None
+
+
+def _png_z_mapy(dane: bytes, szerokosc: int, wysokosc: int,
+                kanaly: int, bitow: int) -> bytes | None:
+    """Składa PNG z surowej mapy bitowej."""
+    typ = {1: 0, 3: 2}.get(kanaly)          # 0 = szary, 2 = RGB; CMYK odpada
+    if typ is None or bitow not in (1, 2, 4, 8):
+        return None
+
+    bajtow_na_wiersz = (szerokosc * kanaly * bitow + 7) // 8
+    if len(dane) < bajtow_na_wiersz * wysokosc:
+        return None
+
+    # PNG wymaga bajtu filtra przed każdym wierszem.
+    wiersze = bytearray()
+    for y in range(wysokosc):
+        wiersze.append(0)
+        wiersze += dane[y * bajtow_na_wiersz:(y + 1) * bajtow_na_wiersz]
+
+    def kawalek(nazwa: bytes, tresc: bytes) -> bytes:
+        return (struct.pack(">I", len(tresc)) + nazwa + tresc
+                + struct.pack(">I", zlib.crc32(nazwa + tresc) & 0xFFFFFFFF))
+
+    naglowek = struct.pack(">IIBBBBB", szerokosc, wysokosc, bitow, typ, 0, 0, 0)
+    return (b"\x89PNG\r\n\x1a\n"
+            + kawalek(b"IHDR", naglowek)
+            + kawalek(b"IDAT", zlib.compress(bytes(wiersze), 6))
+            + kawalek(b"IEND", b""))
+
+
+def obrazy_z_pdf(dane: bytes, maks: int = 40) -> list[tuple[str, bytes]]:
+    """Obrazy osadzone w PDF jako [(rozszerzenie, bajty)]."""
+    wynik: list[tuple[str, bytes]] = []
+
+    for _, _, cialo in _OBIEKT.findall(dane):
+        if len(wynik) >= maks:
+            break
+        slownik = cialo.split(b"stream", 1)[0]
+        if not re.search(rb"/Subtype\s*/Image", slownik):
+            continue
+        strumien = _STRUMIEN.search(cialo)
+        if not strumien:
+            continue
+        surowy = strumien.group(1)
+
+        if b"/DCTDecode" in slownik:
+            wynik.append(("jpg", surowy))       # strumień JEST plikiem JPEG
+            continue
+
+        if b"/FlateDecode" not in slownik:
+            continue
+        try:
+            mapa = zlib.decompress(surowy)
+        except zlib.error:
+            continue
+
+        szerokosc = _liczba(slownik, rb"/Width")
+        wysokosc = _liczba(slownik, rb"/Height")
+        bitow = _liczba(slownik, rb"/BitsPerComponent") or 8
+        if not szerokosc or not wysokosc:
+            continue
+        kanaly = (3 if b"/DeviceRGB" in slownik else
+                  4 if b"/DeviceCMYK" in slownik else 1)
+
+        png = _png_z_mapy(mapa, szerokosc, wysokosc, kanaly, bitow)
+        if png:
+            wynik.append(("png", png))
+
+    return wynik
+
+
+# ── rozpoznawanie ────────────────────────────────────────────────────
+
+def z_obrazu(obraz: bytes, rozszerzenie: str = "png", jezyk: str = "pl") -> str:
+    program = sciezka_programu()
+    if not program:
+        raise BladOCR(
+            "Nie znaleziono programu Tesseract. OCR jest wyłączony — skany "
+            "trzeba rozpoznać w osobnym narzędziu przed wgraniem.")
+
+    kod = JEZYKI.get(jezyk, "pol")
+    if kod not in jezyki_dostepne():
+        raise BladOCR(
+            f"Brak pakietu językowego {kod} dla Tesseracta. Rozpoznawanie "
+            f"polskiego pisma bez niego daje tekst BEZ ZNAKÓW "
+            f"DIAKRYTYCZNYCH, co czyni cytaty niewiarygodnymi — dlatego "
+            f"odmawiamy zamiast schodzić na angielski.")
+
+    with tempfile.TemporaryDirectory() as katalog:
+        plik = Path(katalog) / f"strona.{rozszerzenie}"
+        plik.write_bytes(obraz)
+        try:
+            wynik = subprocess.run(
+                [program, str(plik), "stdout", "-l", kod],
+                capture_output=True, env=_srodowisko(), timeout=TIMEOUT_S)
+        except subprocess.TimeoutExpired as e:
+            raise BladOCR(f"Rozpoznawanie przekroczyło {TIMEOUT_S} s.") from e
+        except OSError as e:
+            raise BladOCR(f"Nie udało się uruchomić Tesseracta: {e}") from e
+
+    if wynik.returncode != 0:
+        raise BladOCR(
+            "Tesseract zakończył się błędem: "
+            + (wynik.stderr or b"").decode("utf-8", "replace").strip()[:200])
+    return (wynik.stdout or b"").decode("utf-8", "replace")
+
+
+def z_pdf(dane: bytes, jezyk: str = "pl") -> WynikOCR:
+    """Rozpoznanie skanu zapisanego jako PDF."""
+    obrazy = obrazy_z_pdf(dane)
+    if not obrazy:
+        raise BladOCR(
+            "W tym PDF-ie nie ma obrazów możliwych do rozpoznania. Strony są "
+            "wektorowe — plik ma warstwę tekstową, której nie da się "
+            "odczytać, a nie skan. Zapisz go ponownie jako obraz albo wgraj "
+            "w innym formacie.")
+
+    czesci, ostrzezenia = [], []
+    for rozszerzenie, obraz in obrazy:
+        try:
+            czesci.append(z_obrazu(obraz, rozszerzenie, jezyk))
+        except BladOCR as e:
+            ostrzezenia.append(str(e))
+
+    if not czesci:
+        raise BladOCR(
+            "Żadnej ze stron nie udało się rozpoznać. "
+            + (ostrzezenia[0] if ostrzezenia else ""))
+
+    return WynikOCR(tekst="\n\n".join(czesci), stron=len(czesci),
+                    jezyk=JEZYKI.get(jezyk, "pol"), ostrzezenia=ostrzezenia)

--- a/panel/serwer.py
+++ b/panel/serwer.py
@@ -36,6 +36,7 @@ import przepisy as mod_przepisy  # noqa: E402
 import eksport as mod_eksport  # noqa: E402
 import kopia as mod_kopia  # noqa: E402
 import terminy as mod_terminy  # noqa: E402
+import ocr as mod_ocr  # noqa: E402
 import wczytywanie as mod_wczytywanie  # noqa: E402
 import zadania as mod_zadania  # noqa: E402
 
@@ -211,7 +212,11 @@ class Uchwyt(BaseHTTPRequestHandler):
         wczytane, odrzucone = [], []
         for nazwa, bajty in pliki:
             try:
-                wynik = mod_wczytywanie.wczytaj(nazwa, bajty)
+                # OCR wyłącznie na wyraźne życzenie — patrz `panel/ocr.py`.
+                wynik = mod_wczytywanie.wczytaj(
+                    nazwa, bajty,
+                    ocr_dozwolony=str(pola.get("ocr", "")).lower()
+                    in ("1", "true", "tak"))
             except mod_wczytywanie.BladWczytywania as e:
                 odrzucone.append({"nazwa": nazwa, "powod": str(e)})
                 continue
@@ -222,6 +227,9 @@ class Uchwyt(BaseHTTPRequestHandler):
                     "powod": " ".join(wynik.ostrzezenia) or
                              "Nie udało się wydobyć tekstu.",
                     "wymaga_ocr": wynik.wymaga_ocr,
+                    # Panel pokazuje przycisk „rozpoznaj" tylko wtedy, gdy
+                    # OCR jest faktycznie dostępny z polskim pakietem.
+                    "ocr_dostepny": mod_ocr.stan()["dostepny"],
                 })
                 baza.zapisz_audyt(
                     DB, "dokument.odrzucony", sprawa_id,
@@ -231,13 +239,16 @@ class Uchwyt(BaseHTTPRequestHandler):
             try:
                 dok_id = baza.dodaj_dokument(
                     DB, sprawa_id, nazwa, wynik.tekst,
-                    rodzaj=pola.get("rodzaj") or "pismo")
+                    rodzaj=pola.get("rodzaj") or "pismo",
+                    zrodlo_tekstu=wynik.zrodlo)
             except ValueError as e:
                 odrzucone.append({"nazwa": nazwa, "powod": str(e)})
                 continue
 
             wczytane.append({"id": dok_id, "nazwa": nazwa, "typ": wynik.typ,
                              "znakow": wynik.znakow,
+                             "zrodlo": wynik.zrodlo,
+                             "stron_ocr": wynik.stron_ocr,
                              "ostrzezenia": wynik.ostrzezenia})
             baza.zapisz_audyt(
                 DB, "dokument.wgrany", sprawa_id,
@@ -855,7 +866,8 @@ class Uchwyt(BaseHTTPRequestHandler):
             try:
                 dok_id = baza.dodaj_dokument(
                     DB, sprawa_id, nazwa, tresc,
-                    rodzaj=dane.get("rodzaj", "pismo"))
+                    rodzaj=dane.get("rodzaj", "pismo"),
+                    zrodlo_tekstu=mod_wczytywanie.ZRODLO_WKLEJONY)
             except ValueError as e:
                 return _json(self, {"blad": str(e)}, 404)
             return _json(self, {"id": dok_id}, 201)
@@ -949,6 +961,8 @@ class Uchwyt(BaseHTTPRequestHandler):
                  for d in baza.lista_dokumentow(DB, sprawa_id)}
         # Język rozpoznany przy wgraniu — steruje doborem modelu mapowania.
         jezyki = baza.jezyki_dokumentow(DB, sprawa_id)
+        # Pochodzenie tekstu — trafia na każdy cytat, patrz `analiza.analizuj`.
+        zrodla = baza.zrodla_dokumentow(DB, sprawa_id)
         # ────────────────────────────────────────────────────────────
 
         # Przepisy to ODRĘBNA przestrzeń — jawna, wspólna dla spraw,
@@ -979,7 +993,7 @@ class Uchwyt(BaseHTTPRequestHandler):
             wynik = analiza.analizuj(
                 pytanie, dokumenty, nazwy,
                 przepisy=tresci_p or None, nazwy_przepisow=nazwy_p,
-                postep=melduj, jezyki=jezyki,
+                postep=melduj, jezyki=jezyki, zrodla=zrodla,
             )
             slownik = wynik.na_slownik()
             if not wynik.blad:

--- a/panel/statyczne/index.html
+++ b/panel/statyczne/index.html
@@ -147,6 +147,10 @@ mark.cytowane{background:#fde68a;box-shadow:0 0 0 3px #fde68a;border-radius:2px}
                   border:1px solid var(--ostrzezenie)}
   .znacznik.niezweryfikowane{background:var(--tlo);color:var(--przygaszony);
                              border:1px solid var(--przygaszony)}
+/* Pochodzenie z OCR-u wyróżnione mocniej niż stopień wsparcia: to
+   informacja o ŹRÓDLE, nie o jakości dopasowania. */
+  .znacznik.ocr{background:var(--ostrzezenie-tlo);color:var(--ostrzezenie);
+                border:1px solid var(--ostrzezenie);font-weight:800}
   .cytat .uwaga-kontroli{display:block;font-size:.73rem;margin-top:.3rem;
                          color:var(--ostrzezenie);font-weight:600}
 /* Błąd kontroli niezależnej — nie znacznik, tylko widoczny komunikat.
@@ -1128,6 +1132,14 @@ let sprawaAktywna=null, dokumentAktywny=null, sondowanie=null;
 /* Dokumenty zaznaczone kwadracikiem — wybór PRAWNIKA, którego system
    nie zawęża po swojemu (agent._zawez_dokumenty, wybor_uzytkownika). */
 let zaznaczone = new Set(), dokumentyWszystkie = [];
+/* Ostatnio wgrywane pliki — żeby „Rozpoznaj pismo" nie kazało wybierać
+   ich po raz drugi. */
+let ostatnioWgrywane = null;
+
+async function ponowZOcr(){
+  if(!ostatnioWgrywane){ alert('Wybierz plik ponownie.'); return; }
+  await wgrajPliki(ostatnioWgrywane, true);
+}
 
 const api=async(s,o={})=>{
   const r=await fetch(s,{headers:{'Content-Type':'application/json; charset=utf-8'},...o});
@@ -1783,7 +1795,9 @@ async function wczytajDokumenty(){
             onclick="event.stopPropagation()"></label>
          <span onclick="zawezDo(${d.id})" style="cursor:pointer">
            <span class="syg">${esc(d.nazwa)}</span>
-           <span class="meta">${esc(d.rodzaj)} · ${d.dlugosc} zn.</span></span></div>`).join('')
+           <span class="meta">${esc(d.rodzaj)} · ${d.dlugosc} zn.${
+             d.zrodlo_tekstu==='ocr' ? ' · <b style="color:var(--ostrzezenie)">z OCR</b>' : ''
+           }</span></span></div>`).join('')
     : '<div class="pusto">Brak dokumentów.</div>');
   await odswiezStrategie();
 }
@@ -1835,7 +1849,10 @@ async function odswiezStrategie(){
    warstwy tekstowej albo plik w pomylonej stronie kodowej NIE wchodzi
    do akt — wpuszczenie go zamieniłoby weryfikację cytatów w teatr:
    cytat zgadzałby się znak w znak ze zniekształconym źródłem.        */
-async function wgrajPliki(pliki){
+/* `ocr` domyślnie WYŁĄCZONE. Rozpoznawanie obrazu zamienia treść pisma
+   na jej odczyt, więc obniża rangę cytatu — musi być świadomą decyzją,
+   a nie zachowaniem domyślnym.                                        */
+async function wgrajPliki(pliki, ocr){
   if(!sprawaAktywna){alert('Najpierw wybierz sprawę.');return;}
   if(!pliki || !pliki.length) return;
 
@@ -1845,6 +1862,7 @@ async function wgrajPliki(pliki){
 
   const dane = new FormData();
   dane.append('rodzaj', val('d-rodzaj') || 'pismo');
+  if(ocr) dane.append('ocr', '1');
   for(const p of pliki) dane.append('pliki', p, p.name);
 
   let w;
@@ -1867,15 +1885,27 @@ async function wgrajPliki(pliki){
   for(const d of (w.odrzucone||[])){
     czesci.push(`<div class="wgrany-blad"><b>✕ ${esc(d.nazwa)} — nie wczytano</b>
       <div>${esc(d.powod)}</div>
-      ${d.wymaga_ocr?`<div class="opis" style="margin-top:.3rem">
-        Ten plik wymaga OCR-u. Rozpoznaj tekst w programie, w którym
-        otwierasz skany, zapisz jako PDF z warstwą tekstową albo DOCX
-        i wgraj ponownie.</div>`:''}
+      ${d.wymaga_ocr ? (d.ocr_dostepny
+        ? `<div class="opis" style="margin-top:.4rem">
+             To skan — tekstu nie ma w pliku, jest tylko obraz.
+             <button onclick="ponowZOcr()" style="margin-left:.3rem">
+               Rozpoznaj pismo (OCR)</button>
+             <div style="margin-top:.3rem">⚠️ Odczyt obrazu bywa różny od
+               pisma, najczęściej w sygnaturach, kwotach i datach. Dokument
+               dostanie trwały znacznik, a każdy cytat z niego —
+               ostrzeżenie.</div>
+           </div>`
+        : `<div class="opis" style="margin-top:.3rem">
+             Ten plik wymaga OCR-u, a OCR nie jest na tym komputerze
+             dostępny. Rozpoznaj tekst w swoim programie do skanów, zapisz
+             jako PDF z warstwą tekstową albo DOCX i wgraj ponownie.</div>`)
+        : ''}
     </div>`);
   }
   if(w.blad) czesci.push(`<div class="blad">${esc(w.blad)}</div>`);
   cel.innerHTML = czesci.join('');
 
+  ostatnioWgrywane = pliki;
   document.getElementById('d-pliki').value = '';
   await wczytajDokumenty(); await wczytajSprawy();
 }
@@ -2035,6 +2065,16 @@ function pokazBlad(t){
    pokazywana. Kolejność sprawdzania odpowiada mocy dowodu: werdykt
    kontrolera przed pokryciem leksykalnym, bo kontroler czyta sens,
    a pokrycie liczy słowa.                                             */
+/* Pochodzenie tekstu. Stoi PRZED znacznikiem kontroli, bo odpowiada na
+   pytanie wcześniejsze: czy to w ogóle jest treść pisma, czy jej odczyt.
+   Cytat „sprawdzony" z OCR-u nadal jest sprawdzony wobec ODCZYTU.     */
+function znacznikZrodla(c){
+  if(c.zrodlo_tekstu !== 'ocr') return '';
+  return '<span class="znacznik ocr" title="Tekst pochodzi z rozpoznania '+
+         'obrazu. Odczyt bywa różny od pisma — sprawdź przy oryginale.">'+
+         'z OCR</span>';
+}
+
 function znacznikWsparcia(c){
   if(c.kontrola === 'prawda')
     return '<span class="znacznik mocne" title="Niezależna kontrola na czystym '+
@@ -2060,6 +2100,8 @@ const LEGENDA = `<div class="legenda">
   modelu. &nbsp;·&nbsp;
   <b>niezweryfikowane</b> — kontrola nie zadziałała; brak potwierdzenia
   nie jest potwierdzeniem. &nbsp;·&nbsp;
+  <b>z OCR</b> — dokument powstał z rozpoznania obrazu; cytat wskazuje
+  znak w ODCZYCIE skanu, nie w piśmie. &nbsp;·&nbsp;
   Każdy cytat pozostaje klikalny — najpewniejszym sprawdzeniem jest
   zawsze zajrzenie do akt.
 </div>`;
@@ -2128,9 +2170,10 @@ function renderuj(w){
              onclick="pokazZrodlo('${c.dokument_id}',${c.poczatek},${c.koniec})"
              title="Pokaż ten fragment w dokumencie">
           <div class="zrodlo">${esc(u.dokument)} · znaki ${c.poczatek}–${c.koniec}
-            ${znacznikWsparcia(c)}
+            ${znacznikZrodla(c)}${znacznikWsparcia(c)}
             <span class="lupa">otwórz w aktach ↗</span></div>
           „${esc(c.fragment)}”
+          ${c.ostrzezenie_zrodla?`<span class="uwaga-kontroli">⚠ ${esc(c.ostrzezenie_zrodla)}</span>`:''}
           ${c.ostrzezenie?`<span class="uwaga-kontroli">⚠ ${esc(c.ostrzezenie)}</span>`:''}
         </div>`).join('')}
       </div>`).join('')+

--- a/panel/wczytywanie.py
+++ b/panel/wczytywanie.py
@@ -71,6 +71,13 @@ class BladWczytywania(ValueError):
     """Błąd do pokazania użytkownikowi wprost."""
 
 
+# Skąd wziął się tekst dokumentu. Znacznik jedzie do bazy i dalej do
+# każdego cytatu — patrz `ZRODLA` niżej.
+ZRODLO_WKLEJONY = "wklejony"
+ZRODLO_PLIK = "plik"
+ZRODLO_OCR = "ocr"
+
+
 @dataclass
 class Wynik:
     tekst: str
@@ -78,6 +85,14 @@ class Wynik:
     znakow: int = 0
     ostrzezenia: list[str] = field(default_factory=list)
     wymaga_ocr: bool = False
+    # ⚠️ POCHODZENIE TEKSTU JEST CZĘŚCIĄ WYNIKU, NIE METADANĄ.
+    #
+    # Tekst z pliku cyfrowego jest treścią pisma. Tekst z OCR-u jest
+    # ODCZYTEM obrazu — bywa różny od pisma, zwłaszcza w sygnaturach,
+    # kwotach i datach. Cytat z jednego i z drugiego wygląda tak samo,
+    # więc różnicę musi nieść dokument, a nie pamięć prawnika.
+    zrodlo: str = ZRODLO_PLIK
+    stron_ocr: int = 0
 
     @property
     def nadaje_sie(self) -> bool:
@@ -271,6 +286,7 @@ def _z_docx(dane: bytes) -> str:
 #   4. bramka jakości na końcu — jeżeli cokolwiek poszło źle, odmawiamy.
 
 _OBIEKT = re.compile(rb"(\d+)\s+(\d+)\s+obj(.*?)endobj", re.DOTALL)
+_OBRAZ = re.compile(rb"/Subtype\s*/Image")
 _STRUMIEN = re.compile(rb"stream\r?\n(.*?)\r?\nendstream", re.DOTALL)
 _TOUNICODE = re.compile(rb"/ToUnicode\s+(\d+)\s+\d+\s+R")
 _FONT_ZASOB = re.compile(rb"/(\w+)\s+(\d+)\s+\d+\s+R")
@@ -370,13 +386,45 @@ def _na_znaki(surowy: bytes, mapa: dict[int, str] | None) -> str:
     return surowy.decode("cp1252", errors="replace")
 
 
+# ⚠️ `Td` NIE ZAWSZE OZNACZA NOWY WIERSZ — USTERKA ZMIERZONA 19.08.2026.
+#
+# Wcześniej każdy operator pozycjonowania dawał przełamanie wiersza.
+# Generatory PDF ustawiają jednak pozycję OSOBNO DLA KAŻDEGO ZNAKU, więc
+# poprawnie odczytany tekst wychodził rozsypany na litery: zamiast
+# „Contact" powstawało siedem wierszy po jednej literze.
+#
+# `Td` przyjmuje przesunięcie `tx ty`. Nowy wiersz jest wtedy i tylko
+# wtedy, gdy zmienia się WSPÓŁRZĘDNA PIONOWA. Przesunięcie poziome to
+# odstęp w tej samej linii — duże daje spację, małe nie daje nic.
 _TEKST_W_STRUMIENIU = re.compile(
     rb"/(\w+)\s+[\d.]+\s+Tf"                     # 1: wybór fontu
     rb"|\((?:[^()\\]|\\.|\([^()]*\))*\)\s*Tj"    # literal + Tj
     rb"|\[(?:[^\[\]\\]|\\.)*\]\s*TJ"             # tablica + TJ
     rb"|<([0-9A-Fa-f\s]+)>\s*Tj"                 # 2: hex + Tj
-    rb"|(T\*|Td|TD|'|\"|ET)",                    # 3: przejścia wiersza
+    rb"|(-?[\d.]+)\s+(-?[\d.]+)\s+(?:Td|TD)"     # 3,4: przesunięcie
+    rb"|(T\*|'|\"|ET)",                          # 5: bezwarunkowy wiersz
     re.DOTALL)
+
+# ⚠️ ODSTĘP DOKŁADAMY SKĄPO — ZMIERZONE 19.08.2026.
+#
+# Próg jest UŁAMKIEM ROZMIARU FONTU, nie wartością bezwzględną: te same
+# jednostki znaczą co innego przy stopniu 12 i przy 42.
+#
+# Rozkład przesunięć poziomych na pliku testowym (3294 próbki, font 12-13):
+#
+#     kwantyl 0,10   3,15        kwantyl 0,75   7,14
+#     kwantyl 0,50   6,41        kwantyl 0,97  10,38
+#
+# Odstępy międzyliterowe i międzywyrazowe NIE rozdzielają się progiem —
+# rozkład jest jednomodalny. Powód jest prosty: ten generator wstawia
+# spacje jako osobne glify, więc nie ma czego dokładać. Próg 1,2 dawał
+# „C o n t a c t” zamiast „Contact” i psuł 6053 znaki na 3524 poprawne.
+#
+# Dlatego dokładamy spację wyłącznie przy skoku WYRAŹNIE większym niż
+# szerokość znaku — taki występuje w PDF-ach bez glifu spacji, gdzie
+# wyrazy rozstawia się pozycją. Pomyłka w tę stronę skleja dwa wyrazy;
+# pomyłka w drugą rozbija każdy wyraz na litery. Pierwsza jest tańsza.
+UDZIAL_ODSTEPU = 1.5
 
 _LITERAL = re.compile(rb"\((?:[^()\\]|\\.|\([^()]*\))*\)")
 _HEX = re.compile(rb"<([0-9A-Fa-f\s]+)>")
@@ -388,16 +436,38 @@ def _tekst_ze_strumienia(strumien: bytes,
     """Tekst z jednego strumienia treści, z podziałem na wiersze."""
     czesci: list[str] = []
     biezaca: dict[int, str] | None = None
+    rozmiar_fontu = 0.0
 
     for dopasowanie in _TEKST_W_STRUMIENIU.finditer(strumien):
         calosc = dopasowanie.group(0)
 
         if dopasowanie.group(1):                       # /F1 12 Tf
             biezaca = mapy.get(dopasowanie.group(1).decode("ascii", "ignore"))
+            # Rozmiar fontu steruje progiem odstępu — patrz UDZIAL_ODSTEPU.
+            stopien = re.search(rb"([0-9.]+)[ ]+Tf", calosc)
+            if stopien:
+                try:
+                    rozmiar_fontu = float(stopien.group(1))
+                except ValueError:
+                    pass
             continue
 
-        if dopasowanie.group(3):                       # koniec wiersza
+        if dopasowanie.group(5):                       # T*, ', ", ET
             czesci.append("\n")
+            continue
+
+        if dopasowanie.group(3) is not None:           # tx ty Td
+            try:
+                poziomo = float(dopasowanie.group(3))
+                pionowo = float(dopasowanie.group(4))
+            except ValueError:
+                continue
+            # Nowy wiersz TYLKO przy zmianie pionu. Przesunięcie
+            # poziome to odstęp w tej samej linii.
+            if pionowo != 0:
+                czesci.append("\n")
+            elif poziomo > UDZIAL_ODSTEPU * (rozmiar_fontu or 10.0):
+                czesci.append(" ")
             continue
 
         if dopasowanie.group(2):                       # <hex> Tj
@@ -469,19 +539,59 @@ def _z_pdf(dane: bytes) -> str:
                 mapy[nazwa.decode("ascii", "ignore")] = mapa
         mapy.setdefault(f"__obj{numer}", mapa)
 
-    # Powiązanie nazw zasobów z fontami po stronie stron dokumentu.
+    # ── POWIĄZANIE NAZWY ZASOBU Z FONTEM ────────────────────────────
+    #
+    # ⚠️ USTERKA ZMIERZONA 19.08.2026 — POWÓD, DLA KTÓREGO PDF-Y WYCHODZIŁY
+    #    JAKO ŚMIECI MIMO POPRAWNIE ZBUDOWANYCH MAP.
+    #
+    # Wcześniej stało tu `re.search(rb"/Font\s*<<(.*?)>>", cialo)`. Słownik
+    # zasobów jest jednak ZAGNIEŻDŻONY — `/Font << /F4 4 0 R /F6 6 0 R >>`
+    # bywa poprzedzony `/XObject << ... >>`, a `(.*?)>>` zatrzymuje się na
+    # pierwszym `>>`, czyli zwykle nie na tym właściwym.
+    #
+    # Zmierzone na pliku testowym: 10 map ToUnicode zbudowanych, 10 fontów
+    # użytych w operatorach `Tf`, ZERO powiązań. Każdy znak szedł więc
+    # ścieżką zapasową cp1252 i wychodził jako przypadkowy bajt.
+    #
+    # Wiązanie idzie teraz po całym dokumencie: nazwa `/Fxx` przypisana
+    # numerowi obiektu, dla którego mamy mapę. Nie jest to pełny rozbiór
+    # zasobów per strona — ale generatory PDF numerują fonty unikatowo
+    # w obrębie pliku, a wynik i tak przechodzi przez bramkę jakości,
+    # która złapie ewentualne pomieszanie.
     for _, (cialo, _) in obiekty.items():
-        zasoby = re.search(rb"/Font\s*<<(.*?)>>", cialo, re.DOTALL)
-        if not zasoby:
-            continue
-        for nazwa, wskazanie in _FONT_ZASOB.findall(zasoby.group(1)):
+        for nazwa, wskazanie in _FONT_ZASOB.findall(cialo):
             klucz = f"__obj{int(wskazanie)}"
             if klucz in mapy:
-                mapy[nazwa.decode("ascii", "ignore")] = mapy[klucz]
+                mapy.setdefault(nazwa.decode("ascii", "ignore"), mapy[klucz])
 
     strony: list[str] = []
     for _, (cialo, tresc) in obiekty.items():
-        if not tresc or b"/Image" in cialo:
+        if not tresc:
+            continue
+        # ⚠️ SŁOWNIK OBIEKTU, NIE CAŁE CIAŁO — USTERKA ZMIERZONA 19.08.2026.
+        #
+        # Wcześniej stało tu `b"/Image" in cialo`, czyli szukanie w CAŁYM
+        # obiekcie razem ze skompresowanym strumieniem. Zamiarem było
+        # pominięcie obrazów; skutkiem — odrzucenie CAŁEGO strumienia
+        # treści strony, gdy tylko gdziekolwiek w nim trafił się ciąg
+        # „/Image". A trafia się zawsze, gdy strona ma logo, pieczątkę,
+        # podpis albo tło.
+        #
+        # Skutek na 173 rzeczywistych PDF-ach: 85 dokumentów Z WARSTWĄ
+        # TEKSTOWĄ zwracało zero znaków i bramka jakości uznawała je za
+        # skany. Pisma procesowe mają nagłówek kancelarii i pieczęć
+        # niemal zawsze, więc trafiało to w przypadek typowy, nie brzegowy.
+        #
+        # Teraz sprawdzamy wyłącznie SŁOWNIK obiektu — czyli to, co stoi
+        # przed słowem kluczowym `stream`.
+        # ⚠️ PARA `/Subtype /Image`, NIE SAM CIĄG `/Image`.
+        #
+        # Słownik strony niesie `/ProcSet [/PDF /Text /ImageB /ImageC]`,
+        # więc zwykłe szukanie `/Image` trafia w `/ImageB` i odrzuca
+        # stronę, która żadnym obrazem nie jest. Pierwsza poprawka tej
+        # usterki wpadła dokładnie w tę pułapkę i nie zmieniła nic.
+        slownik = cialo.split(b"stream", 1)[0]
+        if _OBRAZ.search(slownik):
             continue
         if not re.search(rb"\bBT\b", tresc):
             continue
@@ -575,8 +685,14 @@ def _porzadkuj(tekst: str) -> str:
     return tekst.strip()
 
 
-def wczytaj(nazwa: str, dane: bytes) -> Wynik:
-    """Treść pliku jako tekst, z oceną, czy nadaje się na źródło cytatów."""
+def wczytaj(nazwa: str, dane: bytes, ocr_dozwolony: bool = False) -> Wynik:
+    """Treść pliku jako tekst, z oceną, czy nadaje się na źródło cytatów.
+
+    `ocr_dozwolony` włącza rozpoznawanie pisma dla plików, które bramka
+    jakości odrzuciła. Jest WYŁĄCZONE domyślnie i musi być świadomą
+    decyzją: OCR zamienia treść pisma na jej odczyt, więc obniża rangę
+    cytatu. Zobacz `panel/ocr.py`.
+    """
     if not dane:
         raise BladWczytywania("Plik jest pusty.")
     if len(dane) > MAKS_BAJTOW:
@@ -607,6 +723,43 @@ def wczytaj(nazwa: str, dane: bytes) -> Wynik:
             "Plik był zapisany w pomylonej stronie kodowej (cp1252 zamiast "
             "cp1250) — polskie znaki zostały odtworzone. Sprawdź na oko "
             "pierwsze zdania, zanim oprzesz na tym dokumencie pismo."))
+
+    # ── OCR, gdy warstwa tekstowa zawiodła ───────────────────────────
+    #
+    # ⚠️ OSTATNIA DESKA, NIE PIERWSZY WYBÓR.
+    #
+    # Sięgamy po OCR wyłącznie wtedy, gdy bramka jakości odrzuciła tekst
+    # z pliku — czyli plik jest skanem albo ma fonty nie do odczytania.
+    # Nigdy „na wszelki wypadek": odczyt obrazu jest gorszy od warstwy
+    # tekstowej zawsze, gdy ta druga da się przeczytać.
+    if wymaga_ocr and ocr_dozwolony and typ == "pdf":
+        import ocr as mod_ocr
+
+        try:
+            rozpoznane = mod_ocr.z_pdf(dane, jezyk="pl")
+        except mod_ocr.BladOCR as e:
+            ostrzezenia.append(f"OCR nie powiódł się: {e}")
+            return Wynik(tekst=tekst, typ=typ, znakow=len(tekst),
+                         ostrzezenia=ostrzezenia, wymaga_ocr=True)
+
+        tekst_ocr = _porzadkuj(rozpoznane.tekst)
+        ostrzezenia_ocr, nadal_zle = ocen_jakosc(tekst_ocr, 0, "ocr")
+        if nadal_zle or not tekst_ocr.strip():
+            ostrzezenia.append(
+                "OCR zwrócił tekst, którego nie da się użyć jako źródła "
+                "cytatów. Dokument NIE został wczytany.")
+            return Wynik(tekst=tekst, typ=typ, znakow=len(tekst),
+                         ostrzezenia=ostrzezenia, wymaga_ocr=True)
+
+        return Wynik(
+            tekst=tekst_ocr, typ=typ, znakow=len(tekst_ocr),
+            ostrzezenia=[
+                "Tekst pochodzi z ROZPOZNANIA OBRAZU (OCR), nie z pliku. "
+                "Odczyt bywa różny od pisma — najczęściej w sygnaturach, "
+                "kwotach i datach. Każdy cytat z tego dokumentu sprawdź "
+                "przy oryginale.",
+                *ostrzezenia_ocr, *rozpoznane.ostrzezenia],
+            wymaga_ocr=False, zrodlo=ZRODLO_OCR, stron_ocr=rozpoznane.stron)
 
     return Wynik(tekst=tekst, typ=typ, znakow=len(tekst),
                  ostrzezenia=ostrzezenia, wymaga_ocr=wymaga_ocr)

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,171 @@
+"""OCR — rozpoznawanie pisma ze skanów.
+
+⚠️ NAJWAŻNIEJSZE W TYM PLIKU NIE SĄ TESTY UDANEGO ROZPOZNANIA.
+
+OCR zamienia treść pisma na jej ODCZYT. Odczyt bywa różny od pisma —
+najczęściej w sygnaturach, kwotach i datach, czyli dokładnie tam, gdzie
+stoją wyróżniki i terminy procesowe. Testy pilnują więc trzech rzeczy:
+
+  1. że brak polskiego pakietu kończy się ODMOWĄ, a nie zejściem
+     na angielski (który zwraca tekst wyglądający poprawnie, bez ani
+     jednego znaku diakrytycznego);
+  2. że dokument z OCR-u dostaje TRWAŁY ZNACZNIK pochodzenia;
+  3. że OCR nie włącza się sam — jest ostatnią deską, nie pierwszym
+     wyborem.
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+import pytest
+
+KORZEN = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(KORZEN / "panel"))
+
+import ocr  # noqa: E402
+import wczytywanie as w  # noqa: E402
+
+wymaga_ocr = pytest.mark.skipif(
+    not ocr.stan()["dostepny"],
+    reason="Tesseract z polskim pakietem niedostępny na tej maszynie.")
+
+
+def _png(szerokosc: int, wysokosc: int, wartosc: int = 255) -> bytes:
+    """Minimalny PNG w skali szarości — do testu składania obrazu."""
+    wiersze = bytearray()
+    for _ in range(wysokosc):
+        wiersze.append(0)
+        wiersze += bytes([wartosc]) * szerokosc
+
+    def kawalek(nazwa: bytes, tresc: bytes) -> bytes:
+        return (struct.pack(">I", len(tresc)) + nazwa + tresc
+                + struct.pack(">I", zlib.crc32(nazwa + tresc) & 0xFFFFFFFF))
+
+    return (b"\x89PNG\r\n\x1a\n"
+            + kawalek(b"IHDR", struct.pack(">IIBBBBB", szerokosc, wysokosc,
+                                           8, 0, 0, 0, 0))
+            + kawalek(b"IDAT", zlib.compress(bytes(wiersze)))
+            + kawalek(b"IEND", b""))
+
+
+def _pdf_ze_skanem(obraz: bytes, szerokosc: int, wysokosc: int) -> bytes:
+    """PDF, którego jedyną treścią jest obraz — czyli skan."""
+    spakowany = zlib.compress(obraz)
+    return (b"%PDF-1.4\n"
+            b"1 0 obj\n<< /Type /XObject /Subtype /Image /Width "
+            + str(szerokosc).encode() + b" /Height " + str(wysokosc).encode()
+            + b" /BitsPerComponent 8 /ColorSpace /DeviceGray "
+            b"/Filter /FlateDecode /Length " + str(len(spakowany)).encode()
+            + b" >>\nstream\n" + spakowany + b"\nendstream\nendobj\n%%EOF")
+
+
+# ── dostępność i odmowa ──────────────────────────────────────────────
+
+def test_stan_nie_zgaduje():
+    stan = ocr.stan()
+    assert set(stan) >= {"dostepny", "program", "jezyki", "polski"}
+    # `dostepny` znaczy „da się rozpoznać POLSKIE pismo", nie „jest program".
+    assert stan["dostepny"] == (bool(stan["program"]) and stan["polski"])
+
+
+def test_brak_polskiego_to_odmowa(monkeypatch):
+    """⚠️ ANGIELSKI NIE JEST ZAMIENNIKIEM POLSKIEGO.
+
+    Zmierzone 19.08.2026: angielski Tesseract na polskim postanowieniu
+    zwraca „Sad Okregowy ... oddalit wniosek obroncy 0 dopuszezenie" —
+    tekst wyglądający poprawnie, bez ani jednego znaku diakrytycznego.
+    Cytat z takiego źródła przeszedłby weryfikację znak w znak wobec
+    tekstu, którego w piśmie nie ma.
+    """
+    monkeypatch.setattr(ocr, "jezyki_dostepne", lambda: {"eng", "osd"})
+    monkeypatch.setattr(ocr, "sciezka_programu", lambda: "tesseract")
+
+    with pytest.raises(ocr.BladOCR) as info:
+        ocr.z_obrazu(_png(10, 10), "png", "pl")
+    assert "pol" in str(info.value)
+    assert "DIAKRYTYCZNYCH" in str(info.value)
+
+
+def test_brak_programu_to_odmowa(monkeypatch):
+    monkeypatch.setattr(ocr, "sciezka_programu", lambda: None)
+    with pytest.raises(ocr.BladOCR) as info:
+        ocr.z_obrazu(_png(10, 10), "png", "pl")
+    assert "Tesseract" in str(info.value)
+
+
+# ── wydobywanie obrazów z PDF ────────────────────────────────────────
+
+def test_obraz_flate_skladany_w_png():
+    """Mapa bitowa z PDF-a musi wyjść jako plik, który czyta Tesseract."""
+    surowy = bytes([200]) * (40 * 20)
+    pdf = _pdf_ze_skanem(surowy, 40, 20)
+    obrazy = ocr.obrazy_z_pdf(pdf)
+
+    assert len(obrazy) == 1
+    rozszerzenie, dane = obrazy[0]
+    assert rozszerzenie == "png"
+    assert dane.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_obraz_jpeg_przechodzi_bez_zmian():
+    """Strumień /DCTDecode JEST plikiem JPEG — nie ma czego składać."""
+    jpeg = b"\xff\xd8\xff\xe0" + b"udawany jpeg" * 20 + b"\xff\xd9"
+    pdf = (b"%PDF-1.4\n1 0 obj\n<< /Subtype /Image /Width 10 /Height 10 "
+           b"/Filter /DCTDecode /Length " + str(len(jpeg)).encode()
+           + b" >>\nstream\n" + jpeg + b"\nendstream\nendobj\n%%EOF")
+
+    obrazy = ocr.obrazy_z_pdf(pdf)
+    assert obrazy == [("jpg", jpeg)]
+
+
+def test_pdf_bez_obrazow_konczy_sie_wyjasnieniem():
+    """PDF wektorowy nie jest skanem — komunikat ma to mówić."""
+    pdf = b"%PDF-1.4\n1 0 obj\n<< /Type /Page >>\nendobj\n%%EOF"
+    with pytest.raises(ocr.BladOCR) as info:
+        ocr.z_pdf(pdf)
+    assert "wektorowe" in str(info.value)
+
+
+# ── wpięcie w potok wczytywania ──────────────────────────────────────
+
+def test_ocr_nie_wlacza_sie_sam():
+    """⚠️ OSTATNIA DESKA, NIE PIERWSZY WYBÓR.
+
+    Odczyt obrazu jest gorszy od warstwy tekstowej zawsze, gdy ta druga
+    da się przeczytać. Domyślne włączenie OCR-u obniżałoby rangę cytatów
+    w dokumentach, które żadnego rozpoznawania nie potrzebują.
+    """
+    pdf = _pdf_ze_skanem(bytes([255]) * (30 * 30), 30, 30)
+    wynik = w.wczytaj("skan.pdf", pdf)
+    assert wynik.wymaga_ocr
+    assert not wynik.nadaje_sie
+    assert wynik.zrodlo == w.ZRODLO_PLIK
+
+
+def test_tekst_wklejony_ma_wlasne_pochodzenie():
+    """Dokument wklejony do panelu to nie to samo co wgrany plik."""
+    wynik = w.wczytaj("pismo.txt", "Sąd oddalił wniosek obrońcy.".encode())
+    assert wynik.zrodlo == w.ZRODLO_PLIK      # z pliku
+    assert w.ZRODLO_WKLEJONY == "wklejony"    # osobna wartość dla wklejenia
+
+
+@wymaga_ocr
+def test_skan_rozpoznany_dostaje_znacznik_ocr():
+    """Ścieżka pełna: skan → OCR → dokument oznaczony jako odczyt."""
+    # Obraz jednolicie biały nie da tekstu, więc test sprawdza SAM
+    # przepływ i oznaczenie, a nie jakość rozpoznania.
+    pdf = _pdf_ze_skanem(bytes([255]) * (600 * 200), 600, 200)
+    wynik = w.wczytaj("skan.pdf", pdf, ocr_dozwolony=True)
+
+    # Pusty obraz → OCR nic nie zwraca → dokument NIE wchodzi do akt.
+    assert not wynik.nadaje_sie
+    assert wynik.wymaga_ocr
+
+
+@wymaga_ocr
+def test_polski_jest_dostepny_na_tej_maszynie():
+    assert "pol" in ocr.jezyki_dostepne()


### PR DESCRIPTION
## Zmierzone na 173 rzeczywistych PDF-ach

Umowy, listy intencyjne, oferty, faktury, dokumentacja techniczna, życiorysy, pisma z podpisem odręcznym. **Pliki nie trafiają do repozytorium** (T-6) — zostają same liczby.

| | na starcie | po zmianie |
|---|---:|---:|
| odczytane z warstwy tekstowej | 75 | **87** |
| odczytane przez OCR | — | **16** |
| odrzucone z wyjaśnieniem | 98 | 70 |

## Trzy usterki ekstraktora, każda znaleziona pomiarem

**1. Filtr obrazów odrzucał tekst całych stron.** Warunek `/Image in cialo` szukał ciągu w całym obiekcie razem ze skompresowanym strumieniem, więc **każda strona z logo, pieczątką albo podpisem traciła cały tekst**. Pisma procesowe mają nagłówek i pieczęć niemal zawsze — to był przypadek typowy, nie brzegowy. Pierwsza poprawka nie zmieniła nic, bo `/ProcSet [/PDF /Text /ImageB]` zawiera `/Image` jako przedrostek.

**2. Mapy `/ToUnicode` budowane i nieużywane.** Wiązanie nazwy zasobu z mapą szło regexpem `/Font <<(.*?)>>`, a słownik zasobów jest zagnieżdżony. Zmierzone: **10 map zbudowanych, 10 fontów użytych, zero powiązań** — każdy znak szedł zapasowym cp1252 i wychodził jako przypadkowy bajt.

**3. Każdy `Td` łamał wiersz**, a generatory ustawiają pozycję osobno dla każdego znaku: wychodziło `C o n t a c t` zamiast `Contact`. Próg odstępu jest teraz ułamkiem stopnia pisma, bo rozkład przesunięć okazał się jednomodalny (3294 próbki: 3,15 / 6,41 / 7,14 / 10,38).

## OCR

Tesseract jako **osobny proces**, jak Ollama — zero nowych zależności Pythona. Obrazy wydobywane z PDF-a przez `zlib` i `struct`. Dane językowe w `models/tessdata/`, przypięte `sha256`, poza repozytorium; `TESSDATA_PREFIX` wskazuje katalog projektu, więc instalacja nie wymaga administratora.

**Polski jest wymagany, angielski nie jest zamiennikiem:**

```
pol:  Sąd Okręgowy … oddalił wniosek obrońcy o dopuszczenie
eng:  Sad Okregowy … oddalit wniosek obroncy 0 dopuszezenie
```

Angielski „działa" i zwraca tekst bez ani jednego znaku diakrytycznego. Brak polskiego pakietu to **odmowa**, nie zejście na angielski.

## OCR zmienia charakter głównej gwarancji

> *cytat prowadzi do znaku w aktach* → *do znaku **w odczycie skanu***

W pomiarze data z odręcznego wypełnienia wyszła jako `4 9.03.2026`. Przy terminie procesowym to różnica między dochowaniem a utratą terminu. Dlatego dokument dostaje trwały znacznik w bazie, każdy cytat niesie `z OCR` i ostrzeżenie, znacznik jest wystawiany **bezwarunkowo** (poza przełącznikami kontroli — ostrzeżenie gasnące przy zmianie niezwiązanego przełącznika byłoby gorsze od jego braku), a OCR **nie włącza się sam**.

Pochodzenie tekstu śledzone dla **wszystkich** dróg wejścia: `wklejony` · `plik` · `ocr`.

## Czego to nie robi

70 plików zostaje nieodczytanych — PDF-y wektorowe z fontami nie do rozszyfrowania bez pełnego rozbioru kodowań. Nie ma w nich obrazu do rozpoznania, a renderowanie wymagałoby popplera albo Ghostscriptu. Panel mówi to wprost zamiast zwracać pusty dokument.

## Testy

`577 passed, 123 skipped, 1 warning` — liczby w QUICKSTART i CONTRIBUTING zaktualizowane, bo doszło 8 testów.

Szczegóły: [`docs/23-wczytywanie-i-ocr.md`](docs/23-wczytywanie-i-ocr.md)
