### PR TITLE
Dokument z bajtem NUL pokazywal sie jako pusty

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ as an incident rather than a bug.
 python -m pytest tests/ -q --dozwol-pominiecie
 ```
 
-Expected: `577 passed, 123 skipped, 1 warning`. The skips need Docker, the
+Expected: `582 passed, 123 skipped, 1 warning`. The skips need Docker, the
 OpenContracts fork or the measurement corpora; the warning is the deliberate
 J-3 gap. Anything failing is a genuine failure.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -295,12 +295,12 @@ python -m pytest tests/ -q --dozwol-pominiecie
 **You should see**, after about two minutes:
 
 ```
-577 passed, 123 skipped, 1 warning
+582 passed, 123 skipped, 1 warning
 ```
 
 **All three numbers are normal.** What they mean:
 
-- **577 passed** - if any fail, something is genuinely wrong; do not load real
+- **582 passed** - if any fail, something is genuinely wrong; do not load real
   case files until you know what.
 - **123 skipped** - tests needing Docker, the OpenContracts fork or the
   measurement corpora, none of which this guide installs. Skipped is the

--- a/panel/wczytywanie.py
+++ b/panel/wczytywanie.py
@@ -116,6 +116,30 @@ MAKS_UDZIAL_SMIECI = 0.15
 _SMIEC = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\ufffd\ufeff]")
 
 
+def usun_sterujace(tekst: str) -> tuple[str, int]:
+    """Zwraca (tekst bez znaków sterujących, ile usunięto).
+
+    ⚠️ USTERKA ZMIERZONA 19.08.2026 — DOKUMENT WYGLĄDAŁ NA PUSTY.
+
+    Znaki sterujące to nierozszyfrowane glify, nigdy treść pisma. Bajt
+    NUL wśród nich ma jednak skutek uboczny, którego nie widać:
+    **LENGTH() w SQLite zatrzymuje się na pierwszym NUL-u**.
+
+    Faktura o 2672 znakach, z pierwszym NUL-em na pozycji 31, pokazywała
+    się na liście dokumentów jako `31 zn.` Treść była w bazie w całości
+    i model ją widział — ale prawnik patrzył na pozycję wyglądającą na
+    pustą i nie miał powodu jej otwierać.
+
+    Usuwamy je PO ocenie jakości, nie przed: bramka ma widzieć prawdziwy
+    udział śmieci i na nim decydować. Tutaj tylko sprzątamy to, co i tak
+    zostało dopuszczone, i mówimy ile.
+    """
+    if not tekst:
+        return tekst, 0
+    oczyszczony = _SMIEC.sub("", tekst)
+    return oczyszczony, len(tekst) - len(oczyszczony)
+
+
 def ocen_jakosc(tekst: str, bajtow: int, typ: str) -> tuple[list[str], bool]:
     """Zwraca (ostrzeżenia, czy_wymaga_ocr).
 
@@ -751,6 +775,7 @@ def wczytaj(nazwa: str, dane: bytes, ocr_dozwolony: bool = False) -> Wynik:
             return Wynik(tekst=tekst, typ=typ, znakow=len(tekst),
                          ostrzezenia=ostrzezenia, wymaga_ocr=True)
 
+        tekst_ocr, usunietych_ocr = usun_sterujace(tekst_ocr)
         return Wynik(
             tekst=tekst_ocr, typ=typ, znakow=len(tekst_ocr),
             ostrzezenia=[
@@ -760,6 +785,15 @@ def wczytaj(nazwa: str, dane: bytes, ocr_dozwolony: bool = False) -> Wynik:
                 "przy oryginale.",
                 *ostrzezenia_ocr, *rozpoznane.ostrzezenia],
             wymaga_ocr=False, zrodlo=ZRODLO_OCR, stron_ocr=rozpoznane.stron)
+
+    # Znaki sterujące usuwamy PO ocenie jakości — patrz `usun_sterujace`.
+    if not wymaga_ocr:
+        tekst, usunietych = usun_sterujace(tekst)
+        if usunietych:
+            ostrzezenia.append(
+                f"Usunięto {usunietych} znaków, których nie dało się "
+                f"rozszyfrować. Dokument jest wczytany, ale NIEPEŁNY — "
+                f"w tych miejscach brakuje treści.")
 
     return Wynik(tekst=tekst, typ=typ, znakow=len(tekst),
                  ostrzezenia=ostrzezenia, wymaga_ocr=wymaga_ocr)

--- a/tests/test_wczytywanie.py
+++ b/tests/test_wczytywanie.py
@@ -200,3 +200,49 @@ def test_dzielenie_wyrazu_na_koncu_wiersza_sklejane():
     wynik = w.wczytaj("pismo.txt",
                       "postano-\nwienie sądu jest prawomocne.".encode("utf-8"))
     assert "postanowienie" in wynik.tekst
+
+
+# ── znaki sterujące a długość w bazie ────────────────────────────────
+
+def test_znaki_sterujace_usuwane_z_wczytanego_tekstu():
+    """⚠️ USTERKA ZMIERZONA 19.08.2026 — DOKUMENT WYGLĄDAŁ NA PUSTY.
+
+    Bajt NUL w treści ma skutek uboczny, którego nie widać: `LENGTH()`
+    w SQLite zatrzymuje się na nim. Faktura o 2672 znakach, z pierwszym
+    NUL-em na pozycji 31, pokazywała się na liście dokumentów jako
+    `31 zn.` — treść była w bazie w całości, ale prawnik patrzył na
+    pozycję wyglądającą na pustą i nie miał powodu jej otwierać.
+    """
+    tekst = "Sąd oddalił wniosek\x00 obrońcy\x01 o dopuszczenie dowodu."
+    wynik = w.wczytaj("pismo.txt", tekst.encode("utf-8"))
+
+    assert wynik.nadaje_sie
+    assert "\x00" not in wynik.tekst
+    assert "\x01" not in wynik.tekst
+    assert "Sąd oddalił wniosek" in wynik.tekst
+
+
+def test_usuniecie_znakow_jest_zglaszane():
+    """Dokument niepełny musi o tym mówić — brak treści jest niewidoczny."""
+    tekst = "Treść pisma procesowego" + "\x00" * 5 + " ciąg dalszy."
+    wynik = w.wczytaj("pismo.txt", tekst.encode("utf-8"))
+    assert any("NIEPEŁNY" in o for o in wynik.ostrzezenia)
+
+
+def test_zdrowy_tekst_nie_dostaje_ostrzezenia():
+    wynik = w.wczytaj("pismo.txt", ZDANIE.encode("utf-8"))
+    assert not any("NIEPEŁNY" in o for o in wynik.ostrzezenia)
+    assert wynik.tekst == ZDANIE
+
+
+def test_usun_sterujace_liczy_ile_usunelo():
+    oczyszczony, ile = w.usun_sterujace("a\x00b\x01c\x1fd")
+    assert oczyszczony == "abcd"
+    assert ile == 3
+
+
+def test_tabulator_i_nowa_linia_zostaja():
+    """Nie każdy znak poniżej spacji to śmieć — układ tekstu ma znaczenie."""
+    oczyszczony, ile = w.usun_sterujace("wiersz\tkolumna\nnastępny")
+    assert oczyszczony == "wiersz\tkolumna\nnastępny"
+    assert ile == 0


### PR DESCRIPTION
## Objaw

Faktura o **2672 znakach** pojawiała się na liście dokumentów jako **`31 zn.`** Endpoint zgłaszał poprawne 2672, w bazie leżała pełna treść i model ją widział — ale prawnik patrzył na pozycję wyglądającą na pustą i nie miał powodu jej otwierać.

Znalezione przy próbie wgrywania **przez panel, po HTTP**, na prawdziwych plikach.

## Przyczyna

Nierozszyfrowane glify PDF-a wychodzą jako znaki sterujące. Bajt NUL wśród nich ma skutek uboczny, którego nie widać:

> **`LENGTH()` w SQLite zatrzymuje się na pierwszym NUL-u.**

Pierwszy był na pozycji 31.

Bramka jakości tego nie złapała i **słusznie**: 247 znaków sterujących na 2672 to 10,5% przy progu 15%. Dokument nadawał się do użytku — tyle że był niepełny.

## Poprawka

Znaki sterujące usuwane **po** ocenie jakości, nie przed: bramka ma widzieć prawdziwy udział śmieci i na nim decydować. Tutaj sprzątamy to, co i tak zostało dopuszczone, i **mówimy ile** — dokument dostaje ostrzeżenie, że jest wczytany, ale **niepełny**.

Tabulator i nowa linia zostają: nie każdy znak poniżej spacji to śmieć, a układ tekstu ma znaczenie przy podziale na zdania (ADR-0007).

Ta sama ścieżka działa dla tekstu z OCR-u.

## Sprawdzone przez panel

| | wynik |
|---|---|
| DOCX | 201 · `zrodlo=plik` |
| Markdown | 201 · `zrodlo=plik` |
| TXT (cp1250) | 201 · polskie znaki odzyskane |
| PDF z warstwą tekstową | 201 · **2386 zn. zamiast 31** |
| skan bez OCR | **400 — odrzucony z instrukcją** |
| ten sam skan z OCR | 201 · `zrodlo=ocr`, 2 strony, ostrzeżenie przy cytatach |

`582 passed, 123 skipped, 1 warning` — 5 nowych testów, liczby w QUICKSTART i CONTRIBUTING zaktualizowane.
